### PR TITLE
Initial commit.  HTTPS is enabled.

### DIFF
--- a/Design/Design - pegacorn-communicate-roomserver
+++ b/Design/Design - pegacorn-communicate-roomserver
@@ -1,0 +1,106 @@
+Setup a Synapse server running in Docker using Kubernete and Helm
+=================================================================
+These instructions will setup Synapse to use SSL.
+SQLite is being used but this will be changed to Postgres.
+
+
+Git
+===
+https://github.com/fhirbox/pegacorn-communicate-roomserver
+
+
+Image
+=======
+Docker Hub image "matrixdotorg/synapse" is being used.
+
+matrixdotorg - https://hub.docker.com/r/matrixdotorg/synapse/
+
+
+Setup
+=====
+This only needs to be done once.
+
+FROM https://github.com/matrix-org/synapse/blob/master/docker/README.md#generating-a-configuration-file
+
+1) On the host machine create the following directories:
+	/var/lib/docker/volumes/synapse-data/_data/config
+	/var/lib/docker/volumes/synapse-data/_data/data
+	
+	Change the permissions for both folders.  Run the following from /var/lib/docker/volumes/synapse-data/_data
+	chmod 777 config
+	chmod 777 data
+	
+	
+2) Then run:
+	docker run -it --rm --mount type=volume,src=synapse-data,dst=/var/lib/synapse/ -e SYNAPSE_SERVER_NAME=chs.local.gov.au -e SYNAPSE_CONFIG_DIR=/var/lib/synapse/config -e SYNAPSE_DATA_DIR=/var/lib/synapse/data/ -e SYNAPSE_REPORT_STATS=no matrixdotorg/synapse:latest generate
+	
+	The SYNAPSE_SERVER_NAME element will be the last part of a user id
+	
+	This will create the following required files in var/lib/docker/volumes/synapse-data/_data/config
+		homeserver.yaml ** This is a default file and needs to be update for ssl **
+		<your server name>.log.config
+		<your server name>.signing.key
+		
+	the var/lib/docker/volumes/synapse-data/_data/data directory will be empty at this stage.
+	
+	
+3) Create your server certificate and key and make sure they are in pem format.
+
+
+4) Copy the certificates to a host path location.  Remember this location as it is needed for the helm command.
+
+
+5) Modify the default homeserver.yaml file and copy it to /var/lib/docker/volumes/synapse-data/_data/config which will overwite the default.
+
+	Changes made for SSL
+		1) Uncomment the following under listeners:
+			 - port: 8448
+		       type: http
+		       tls: true
+		       resources:
+		         - names: [client, federation]
+		
+		2) Uncomment the tls_certificate_path and change the value to:
+			tls_certificate_path: "/var/lib/synapse/certificates/<your certificate>.cer file>"
+			
+		3) Uncomment the tls_private_key_path and change the valaue to:
+			tls_private_key_path: "/var/lib/synapse/certificates/<your key>.key file>"
+	
+	
+6) Add the following to the hosts file
+	pegacorn-communicate-roomserver.site-a
+	
+	
+Build and deploy
+================
+cd E:\dev\pegacorn-communicate-roomserver
+docker build --rm -t pegacorn/pegacorn-communicate-roomserver:1.0 .
+\helm\helm upgrade pegacorn-communicate-roomserver-site-a --install --namespace site-a --set serviceName="pegacorn-communicate-roomserver",basePort=30880,hostPathCerts="<host path to certificates>",hostPath="/var/lib/docker/volumes/synapse-data/_data",imageTag=1.0 helm
+
+On the container these are the file locations:
+	certificates - /var/lib/synapse/certificates
+	configuration - /var/lib/synapse/config
+	data - /var/lib/synapse/data
+	
+/var/lib/synapse is the dst from the generate command run in the setup.
+/var/lib/docker/volumes/synapse-data/_data is where the generate command writes the files too.
+
+hostPathCerts - The location to get the certificate and key from.
+hostPath - The location of the config generated when running the generate command in the setup
+
+
+URL
+===
+Go to the below URL and if everything has been configured correctly then a page will appear containing: "It works! Synapse is running".
+	https://pegacorn-communicate-roomserver.site-a:30880/_matrix/static/
+	
+	
+Create a new user
+=================
+FROM - https://github.com/matrix-org/synapse/blob/master/INSTALL.md#registering-a-user
+
+1) Login in to the container - docker exec -it <container id> sh
+2) cd /var/lib/synapse/config
+3) Run command: register_new_matrix_user -c homeserver.yaml https://localhost:8448
+
+You can now build and deploy pegacorn-communicate-web and logon using the created user.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM matrixdotorg/synapse:latest
+
+ENV SYNAPSE_CONFIG_PATH /var/lib/synapse/config

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,8 @@
+---
+name: pegacorn-communicate-roomserver
+sources:
+- https://github.com/fhirbox/pegacorn-communicate-roomserver
+version: 1.0.0-SNAPSHOT
+version: 1.0.0-SNAPSHOT
+description: pegacorn-communicate-roomserver
+icon: img/icons/camel.svg

--- a/helm/templates/pegacorn-communicate-roomserver-deployment.yaml
+++ b/helm/templates/pegacorn-communicate-roomserver-deployment.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: apps/v1 
+#extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+#    fabric8.io/git-commit: 9835f5100a549e30a10dd1303b0952234aea14b9
+    fabric8.io/iconUrl: img/icons/camel.svg
+    fabric8.io/git-branch: master
+    fabric8.io/metrics-path: dashboard/file/camel-routes.json/?var-project=pegacorn-communicate-roomserver&var-version=1.0.0-SNAPSHOT
+    fabric8.io/scm-tag: HEAD
+    fabric8.io/scm-url: https://github.com/fhirbox/pegacorn-communicate-roomserver
+  labels:
+    app: {{ .Values.serviceName }}
+    provider: fabric8
+    version: 1.0.0-SNAPSHOT
+    group: net.fhirbox.pegacorn
+  name: {{ .Values.serviceName }}
+spec:
+  replicas: {{ .Values.numOfPods | default 2 }}
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: {{ .Values.serviceName }}
+      provider: fabric8
+      group: net.fhirbox.pegacorn
+  template:
+    metadata:
+      annotations:
+#        fabric8.io/git-commit: 9835f5100a549e30a10dd1303b0952234aea14b9
+        fabric8.io/metrics-path: dashboard/file/camel-routes.json/?var-project=pegacorn-communicate-roomserver&var-version=1.0.0-SNAPSHOT
+        fabric8.io/iconUrl: img/icons/camel.svg
+        fabric8.io/git-branch: master
+        fabric8.io/scm-tag: HEAD
+      labels:
+        app: {{ .Values.serviceName }}
+        provider: fabric8
+        version: 1.0.0-SNAPSHOT
+        group: net.fhirbox.pegacorn
+        date: "{{ date "20060102-150405" .Release.Time }}"
+    spec:
+      {{ if (.Values.acrSecretName) }} 
+      imagePullSecrets:
+        - name: {{ .Values.acrSecretName }}
+      {{ end }}
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: computeResources
+                operator: In
+                values:
+                - High
+      containers:
+      - env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: MY_POD_SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: JVM_MAX_HEAP_SIZE
+          value: "1536m"
+        resources:
+          limits:
+            memory: "2048Mi"
+        image: {{ .Values.dockerRepo }}pegacorn/pegacorn-communicate-roomserver:{{ .Values.imageTag }}            
+        imagePullPolicy: IfNotPresent
+        name: synapes
+        ports:
+        - containerPort: 8448
+          name: https
+          protocol: TCP
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/synapse/data
+        - name: config
+          mountPath: /var/lib/synapse/config
+        - name: certificates
+          mountPath: /var/lib/synapse/certificates
+      volumes:
+      - name: data
+        hostPath: 
+          path: {{ .Values.hostPath }}/data
+      - name: config
+        hostPath: 
+          path: {{ .Values.hostPath }}/config
+      - name: certificates
+        hostPath:
+          path: {{ .Values.hostPathCerts }}

--- a/helm/templates/pegacorn-communicate-roomserver-svc.yaml
+++ b/helm/templates/pegacorn-communicate-roomserver-svc.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+#    fabric8.io/git-commit: 9835f5100a549e30a10dd1303b0952234aea14b9
+    prometheus.io/port: "9779"
+    fabric8.io/iconUrl: img/icons/camel.svg
+    fabric8.io/git-branch: master
+    prometheus.io/scrape: "true"
+    fabric8.io/scm-tag: HEAD
+  labels:
+    app: {{ .Values.serviceName }}
+    provider: fabric8
+    version: 1.0.0-SNAPSHOT
+    group: net.fhirbox.pegacorn
+  name: {{ .Values.serviceName }}
+spec:
+  ports:
+  - name: synapse
+    port: {{ .Values.basePort }}
+    protocol: TCP
+    targetPort: 8448
+    nodePort: {{ if (.Values.serviceType) and (eq .Values.serviceType "NodePort")}} {{ .Values.basePort }} {{ end }}
+#TODO end remove once testing is done    
+  selector:
+    app: {{ .Values.serviceName }}
+    provider: fabric8
+    group: net.fhirbox.pegacorn
+  type: {{ .Values.serviceType | default "LoadBalancer" }}


### PR DESCRIPTION
This is the initial commit of the pegacorn communicate roomserver which uses the Matrix Synapse server.  This is running in Docker and uses Kubernetes and Helm.

A homeserver.yaml file will need to be provided and server certificates created.  The design document has instructions on how to generate a default file and how to modify it for HTTPS.  The hostPath param in the helm command needs to point to this file and the hostPathCerts param points to the server certificates.